### PR TITLE
chore: clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ export NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
 npm install
 ```
 
-- Run the server `npm run dev`
+- Run the server `npm run start`
 
 Now you can access it from the command line using [websocat](https://github.com/vi/websocat).
 
@@ -36,7 +36,7 @@ echo '{"command": "sign", "message": "SGVsbG8sIHdvcmxkIQ==", "fingerprint": "YOU
 
 # How to compile for "prod" into single-executable.
 
-`npm run package-all`
+`npm run make:all`
 
 This will create a single executable in the `dist` folder for the specific platform you're running on.
 
@@ -44,5 +44,5 @@ This will create a single executable in the `dist` folder for the specific platf
 
 - [x] Should show itself in the system tray.
 - [x] Show itself in the task bar.
-- [ ] Better UI
+- [x] Better UI
 - [ ] installable without hassle.

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
       // Add a placeholder message if there are no logs
       if (logContainer.childElementCount === 0) {
         const placeholderEntry = document.createElement("div");
-        placeholderEntry.textContent = "No logs yet...";
+        placeholderEntry.textContent = "";
         placeholderEntry.classList.add("log-entry");
         logContainer.appendChild(placeholderEntry);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpg-bridge",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A very basic bridge to gpg over websockets",
   "license": "MIT",
   "main": "main.js",


### PR DESCRIPTION
- trimmed the amount of clutter in the logs
  - shortened timestamps
  - removed verbose key exports

- changed the app menu
  - removed unneeded items, especially ones that caused the app to misbehave

- improved error handling
  - filtered out unretrieveable keys from the getkeys command
  - made verious "success" and "error" messages show up when an action actually succeeded or failed
  - added a 'completion' message for when gpg signing failed

- memoized findGpgPath so that the results from the first successful call get used for later calls.

- added a "version" command which allows a client app to ask what version of gpg-bridge is runnning

- got rid of the kill-port behavior. Well behaved apps dont kill other apps. changed behavior for the app to fail if it is unable to open a server on port 5151.

- changed startup order a little bit to ensure that the main window is ready to show logs before doing anything that generates logs.