### PR TITLE
Bummp version for release 0.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpg-bridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpg-bridge",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpg-bridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A very basic bridge to gpg over websockets",
   "license": "MIT",
   "main": "main.js",


### PR DESCRIPTION
New release inclusive of: https://github.com/unchained-capital/gpg-bridge/pull/29