### PR TITLE
BIZ-816 more secure / less visible passcode generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -143,8 +143,10 @@ function sendToRenderer(channel, data) {
 
 const acceptableRemoteHosts = ['::1', '127.0.0.1', 'localhost'];
 
-const passCode = Math.random().toString().substring(2, 8).padEnd(6, '0');
-console.log('INFO passCode =', passCode);
+// crypto.getRandomValues fills a typed array in place, so we allocate a
+// single-element Uint32Array, read the random uint32 back out, then reduce
+// it into the 6-digit range (0–999_999) and zero-pad to a fixed width.
+const passCode = (crypto.getRandomValues(new Uint32Array(1))[0] % 1_000_000).toString().padStart(6, '0');
 
 // WebSocket Server Setup
 


### PR DESCRIPTION
From Gregor's feedback re: the newly added passcode:

> There was a passcode added to authenticate with gpg-bridge. Still, my recommendation is that we add an origin check, like pentesters recommended, so we only let connections through if they come from a known origin (I believe that this is probably only [vagabond.unchained.com](http://vagabond.unchained.com/)).
> 
> When reevaluating this I found that 2 issues:
> 
> passcodes gets logged. I recommend that log is removed.
> 
> passcode generation doesn't use a true random generator, Math.random is specifically not a good random for these purposes. Please use crypto.getRandomValues() (Web Crypto API) instead.